### PR TITLE
Constrain spacy version to 3.7.5

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     click<7.2.0,>=7.1.1
     pandas>=0.24.2
     scispacy==0.5.5
-    spacy>=3.7.0,<3.8.0
+    spacy==3.7.5
     spacy-transformers>=1.3.4
     textract-py3>=2.1.1
     scikit-learn>=1.5.0


### PR DESCRIPTION
This is becuase scispacy only works till numpy < 2, but the newer spacy versions use numpy version > 2. To fix this issue, simply use an older version of spacy